### PR TITLE
Patch Async Executor TrieMap 

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/writer/AsyncExecutor.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/AsyncExecutor.scala
@@ -44,7 +44,7 @@ class AsyncExecutor[T, R](asyncAction: T => CompletionStage[R], maxConcurrentTas
       value.whenComplete(new BiConsumer[R, Throwable] {
         private def release() {
           semaphore.release()
-          pendingFutures.remove(promise.future) // Could change to be use .poll() if we do not care which promise future to use, any promise from the queue should be fine as long as there's one available
+          pendingFutures.remove(promise.future)
         }
 
         private def onSuccess(result: R) {

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/AsyncExecutor.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/AsyncExecutor.scala
@@ -95,8 +95,7 @@ class AsyncExecutor[T, R](asyncAction: T => CompletionStage[R], maxConcurrentTas
     * It will not wait for tasks scheduled for execution during this method call,
     * nor tasks for which the [[executeAsync]] method did not complete. */
   def waitForCurrentlyExecutingTasks() {
-    while(!pendingFutures.isEmpty){
-      val future = pendingFutures.poll()
+    for (future <- pendingFutures.toArray(new Array[Future[R]](0))){
       Try(Await.result(future, Duration.Inf))
     }
   }


### PR DESCRIPTION
# Description

## How did the Spark Cassandra Connector Work or Not Work Before this Patch

Describe the problem, or state of the project that this patch fixes. Explain
why this is a problem if this isn't obvious.

We were looking at the thread dump to check where the app is spending time/CPU and found this error:
```
java.lang.Object.hashCode(Native Method)
scala.runtime.Statics.anyHash(Statics.java:122)
scala.collection.concurrent.TrieMap$MangledHashing.hash(TrieMap.scala:978)
scala.collection.concurrent.TrieMap.computeHash(TrieMap.scala:823)
scala.collection.concurrent.TrieMap.put(TrieMap.scala:843)
com.datastax.spark.connector.writer.AsyncExecutor.executeAsync(AsyncExecutor.scala:39)
com.datastax.spark.connector.writer.AsyncStatementWriter.$anonfun$write$1(TableWriter.scala:265)
com.datastax.spark.connector.writer.AsyncStatementWriter.$anonfun$write$1$adapted(TableWriter.scala:264)
com.datastax.spark.connector.writer.AsyncStatementWriter$$Lambda$2292/94379871.apply(Unknown Source)
scala.Option.foreach(Option.scala:407)
com.datastax.spark.connector.writer.AsyncStatementWriter.write(TableWriter.scala:264)
com.datastax.spark.connector.writer.TableWriter.$anonfun$writeInternal$4(TableWriter.scala:234)
com.datastax.spark.connector.writer.TableWriter.$anonfun$writeInternal$4$adapted(TableWriter.scala:233)
com.datastax.spark.connector.writer.TableWriter$$Lambda$1944/37410754.apply(Unknown Source)
scala.collection.Iterator.foreach(Iterator.scala:941)
scala.collection.Iterator.foreach$(Iterator.scala:941)
com.datastax.spark.connector.util.CountingIterator.foreach(CountingIterator.scala:4)
com.datastax.spark.connector.writer.TableWriter.writeInternal(TableWriter.scala:233)
com.datastax.spark.connector.writer.TableWriter.write(TableWriter.scala:170)
```
We suspect that the problem is with [this line](https://github.com/datastax/spark-cassandra-connector/blob/master/connector/src/main/scala/com/datastax/spark/connector/writer/AsyncExecutor.scala#L24) `private val pendingFutures = new TrieMap[Future[R], Boolean]`  as it uses future as key so it needs to calculate the hash of the **future** which is a complicated task.

Our goal is to reduce an unnecessary processing time so that we can improve the performance

## General Design of the patch

Changes the data structure for pendingFutures from TrieMap to ConcurrentLinkedQueue. With this change we could achieve two things:
- Keep concurrent safe behavior similar to the previous TrieMap
- Stop hashing Futures.

Fixes: [Put JIRA Reference HERE](https://datastax-oss.atlassian.net/projects/SPARKC)

# How Has This Been Tested?

All existing tests pass.

# Checklist:

- [ ] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/projects/SPARKC)
- [x] I have performed a self-review of my own code
- [x] Locally all tests pass (make sure tests fail without your patch)
